### PR TITLE
Use crlf for row separators

### DIFF
--- a/lib/moss_generator/stripe.rb
+++ b/lib/moss_generator/stripe.rb
@@ -75,7 +75,7 @@ module MossGenerator
     end
 
     def row_separator
-      ";\n"
+      ";\r\n"
     end
 
     def column_separator

--- a/spec/moss_generator/stripe_spec.rb
+++ b/spec/moss_generator/stripe_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe MossGenerator::Stripe do
     before { stub_vat_rates_file }
 
     it 'returns a csv format string' do
-      result = "MOSS_001;\n"\
-               "SE556000016701;3;2020;\n"\
-               "SE;IT;22,00;205,90;45,30;\n"\
-               "SE;FR;20,00;415,00;83,00;\n"\
+      result = "MOSS_001;\r\n"\
+               "SE556000016701;3;2020;\r\n"\
+               "SE;IT;22,00;205,90;45,30;\r\n"\
+               "SE;FR;20,00;415,00;83,00;\r\n"\
 
       expect(call).to eq(result)
     end


### PR DESCRIPTION
\r\n is required for Skatteverket. Depending on mail-client and other factors (Apple Mail -> Gmail, exact reason not confirmed), the file might get converted and includes extra newlines after each row