### PR TITLE
Update vat rates for 2021 quarter 1

### DIFF
--- a/config/vat_rates_2020_4.json
+++ b/config/vat_rates_2020_4.json
@@ -130,7 +130,7 @@
   },
   "DE": {
     "country_name": "Germany",
-    "standard_rate": 19,
+    "standard_rate": 16,
     "reduced_rates": {
       "foodstuffs": 7,
       "books": 7,
@@ -364,6 +364,20 @@
     "reduced_rates": {
       "foodstuffs": 12,
       "books": 6
+    }
+  },
+  "GB": {
+    "country_name": "United Kingdom",
+    "standard_rate": 20,
+    "reduced_rates": {
+      "property renovations": 5,
+      "foodstuffs": 0,
+      "books": 0,
+      "pharmaceuticals": 0,
+      "medical": 0,
+      "passenger transport": 0,
+      "newspapers": 0,
+      "childrens clothing": 0
     }
   }
 }


### PR DESCRIPTION
Skattesatser hämtade från https://europa.eu/youreurope/business/taxation/vat/vat-rules-rates/index_en.htm#shortcut-6 
Källan uppdaterades 1 Januari 2021

Följande är Irländska skatteverkets vat-rates där det står att de uppdaterat sin standard momssats från 21% till 23% från och med 1 mars. https://www.revenue.ie/en/vat/vat-rates/search-vat-rates/current-vat-rates.aspx

Bild tagen 2021-04-14 om sidan ändras
![image](https://user-images.githubusercontent.com/51903586/114670026-dc82ff00-9d02-11eb-806b-11137de9d940.png)
