### PR TITLE
MOSS to OSS corrections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
 Layout/LineLength:
   Max: 80
 
+Metrics/ParameterLists:
+  Max: 6
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/lib/moss_generator/stripe.rb
+++ b/lib/moss_generator/stripe.rb
@@ -8,18 +8,19 @@ module MossGenerator
   class Stripe
     class NoTurnoverCountryError < StandardError; end
 
-    attr_reader :charges, :vat_number, :period, :year, :rates
+    attr_reader :charges, :vat_number, :period, :year, :rates, :sale_type
 
-    def initialize(charges, vat_number, period, year, rates)
+    def initialize(charges, vat_number, period, year, rates, sale_type)
       @charges = charges
       @vat_number = vat_number
       @period = period
       @year = year
       @rates = rates
+      @sale_type = sale_type
     end
 
-    def self.call(charges, vat_number, period, year, rates)
-      new(charges, vat_number, period, year, rates).call
+    def self.call(charges, vat_number, period, year, rates, sale_type)
+      new(charges, vat_number, period, year, rates, sale_type).call
     end
 
     def call
@@ -33,7 +34,7 @@ module MossGenerator
     private
 
     def first_row
-      ['MOSS_001']
+      ['OSS_001']
     end
 
     def second_row
@@ -70,7 +71,8 @@ module MossGenerator
        country,
        format_to_two_decimals(vat),
        format_to_two_decimals(charges.sum(&:amount_without_vat)),
-       format_to_two_decimals(charges.sum(&:vat_amount))]
+       format_to_two_decimals(charges.sum(&:vat_amount)),
+       sale_type]
     end
 
     def csv_options

--- a/spec/moss_generator/stripe_spec.rb
+++ b/spec/moss_generator/stripe_spec.rb
@@ -12,16 +12,17 @@ RSpec.describe MossGenerator::Stripe do
                            'SE556000016701',
                            3,
                            2020,
-                           read_exchange_rates)
+                           read_exchange_rates,
+                           'GOODS')
     end
 
     before { stub_vat_rates_file }
 
     it 'returns a csv format string' do
-      result = "MOSS_001;\r\n"\
+      result = "OSS_001;\r\n"\
                "SE556000016701;3;2020;\r\n"\
-               "SE;IT;22,00;205,90;45,30;\r\n"\
-               "SE;FR;20,00;415,00;83,00;\r\n"\
+               "SE;IT;22,00;205,90;45,30;GOODS;\r\n"\
+               "SE;FR;20,00;415,00;83,00;GOODS;\r\n"\
 
       expect(call).to eq(result)
     end
@@ -35,10 +36,10 @@ RSpec.describe MossGenerator::Stripe do
       end
 
       it 'returns a csv with same country with different vat on two rows' do
-        result = "MOSS_001;\r\n"\
+        result = "OSS_001;\r\n"\
                  "SE556000016701;3;2020;\r\n"\
-                 "SE;IE;23,00;204,23;46,97;\r\n"\
-                 "SE;IE;21,00;205,79;43,22;\r\n"\
+                 "SE;IE;23,00;204,23;46,97;GOODS;\r\n"\
+                 "SE;IE;21,00;205,79;43,22;GOODS;\r\n"\
 
         expect(call).to eq(result)
       end


### PR DESCRIPTION
[OSS](https://www.skatteverket.se/foretag/moms/deklareramoms/ossredovisningavmomsenligtdesarskildaordningarna/tekniskbeskrivningonestopshop.4.96cca41179bad4b1aa1d6.html)
[MOSS](https://www.skatteverket.se/foretag/moms/deklareramoms/mossredovisningavmomspadigitalatjanster/tekniskbeskrivningminionestopshop.4.1c68351d170ce5545273f83.html)

https://standoutab.atlassian.net/browse/UTV-392
[Förändringar MOSS - OSS.md](https://github.com/standout/moss_generator/files/7144080/Forandringar.MOSS.-.OSS.md)

Se rapport på ärendet ovan för skillnader mellan OSS och MOSS

Denna PR lägger endast till de uppdateringarna som anpassar nuvarande lösning till OSS.
Lägger inte in stöd för `CORRECTIONS` som är nytt i OSS