### PR TITLE
Set country code to EL if greece

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    moss_generator (0.5.1)
+    moss_generator (0.5.2)
       countries (~> 4.0)
       money (~> 6.14)
       valvat (~> 1.1)
@@ -28,7 +28,7 @@ GEM
     httpi (2.5.0)
       rack
       socksify
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     i18n_data (0.13.0)
     method_source (1.0.0)
@@ -37,6 +37,8 @@ GEM
       i18n (>= 0.6.4, <= 2)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nori (2.6.0)
     parallel (1.20.1)

--- a/lib/moss_generator/stripe.rb
+++ b/lib/moss_generator/stripe.rb
@@ -68,7 +68,7 @@ module MossGenerator
 
     def country_row(country, charges, vat)
       [turnover_country,
-       country,
+       country_code(country),
        format_to_two_decimals(vat),
        format_to_two_decimals(charges.sum(&:amount_without_vat)),
        format_to_two_decimals(charges.sum(&:vat_amount)),
@@ -85,6 +85,12 @@ module MossGenerator
 
     def column_separator
       ';'
+    end
+
+    def country_code(country)
+      return 'EL' if country == 'GR'
+
+      country
     end
 
     def format_to_two_decimals(number)

--- a/lib/moss_generator/version.rb
+++ b/lib/moss_generator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MossGenerator
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/fixtures/stripe_charges_from_greece.json
+++ b/spec/fixtures/stripe_charges_from_greece.json
@@ -1,0 +1,225 @@
+[
+  {
+    "id": "ch_1I1sjeBqdummy94dh06xTnx",
+    "object": "charge",
+    "amount": 25120,
+    "amount_captured": 25120,
+    "amount_refunded": 0,
+    "application": "ca_3oiFU62JYdummynBL0ept0UZo23o",
+    "application_fee": null,
+    "application_fee_amount": null,
+    "balance_transaction": {
+      "id": "txn_1I1sdummyNmWB",
+      "object": "balance_transaction",
+      "amount": 248687,
+      "available_on": 1609372800,
+      "created": 1608812162,
+      "currency": "sek",
+      "description": "ORD001737: ISO 56002 Innovation Management - Eicorn Academy",
+      "exchange_rate": 9.89996,
+      "fee": 3662,
+      "fee_details": [
+        {
+          "amount": 3662,
+          "application": null,
+          "currency": "sek",
+          "description": "Stripe processing fees",
+          "type": "stripe_fee"
+        }
+      ],
+      "net": 245025,
+      "reporting_category": "charge",
+      "source": {
+        "id": "ch_1I1sjeBqdummy94dh06xTnx",
+        "object": "charge",
+        "amount": 25120,
+        "amount_captured": 25120,
+        "amount_refunded": 0,
+        "application": "ca_3oiFU62JYdummynBL0ept0UZo23o",
+        "application_fee": null,
+        "application_fee_amount": null,
+        "balance_transaction": "txn_1I1sdummy4sa82NmWB",
+        "billing_details": {
+          "address": {
+            "city": null,
+            "country": null,
+            "line1": null,
+            "line2": null,
+            "postal_code": null,
+            "state": null
+          },
+          "email": null,
+          "name": null,
+          "phone": null
+        },
+        "calculated_statement_descriptor": "ACADEMY.EICORN.COM",
+        "captured": true,
+        "created": 1608812162,
+        "currency": "eur",
+        "customer": "cus_IcsdummyFHz",
+        "description": "ORD001737: ISO 56002 Innovation Management - Eicorn Academy",
+        "destination": null,
+        "dispute": null,
+        "disputed": false,
+        "failure_code": null,
+        "failure_message": null,
+        "fraud_details": {},
+        "invoice": null,
+        "livemode": true,
+        "metadata": {
+          "order_id": "20679297",
+          "first_name": "dummy",
+          "last_name": "name",
+          "email": "another_dummy@example.com",
+          "ip_address": "79.9.102.47",
+          "company_or_organisation": "Project Dummy",
+          "country": "GR"
+        },
+        "on_behalf_of": null,
+        "order": null,
+        "outcome": {
+          "network_status": "approved_by_network",
+          "reason": null,
+          "risk_level": "normal",
+          "seller_message": "Payment complete.",
+          "type": "authorized"
+        },
+        "paid": true,
+        "payment_intent": "pi_1I1sjeBqidummycmgk3hI",
+        "payment_method": "pm_1I1cMIdummyuSSxwro",
+        "payment_method_details": {
+          "card": {
+            "brand": "mastercard",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": null
+            },
+            "country": "GR",
+            "exp_month": 7,
+            "exp_year": 2021,
+            "fingerprint": "dummy",
+            "funding": "prepaid",
+            "installments": null,
+            "last4": "0000",
+            "network": "mastercard",
+            "three_d_secure": null,
+            "wallet": null
+          },
+          "type": "card"
+        },
+        "receipt_email": null,
+        "receipt_number": null,
+        "receipt_url": "https://pay.stripe.com/receipts/acct_1dummyfRT94/ch_1I1sjeBqdummy94dh06xTnx/rcpt_Id91eUPCSmxwQ6KC06HgpjAXU3clFtE",
+        "refunded": false,
+        "refunds": {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/charges/ch_1I1sjeBqdummy94dh06xTnx/refunds"
+        },
+        "review": null,
+        "shipping": null,
+        "source": null,
+        "source_transfer": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": null
+      },
+      "status": "available",
+      "type": "charge"
+    },
+    "billing_details": {
+      "address": {
+        "city": null,
+        "country": null,
+        "line1": null,
+        "line2": null,
+        "postal_code": null,
+        "state": null
+      },
+      "email": null,
+      "name": null,
+      "phone": null
+    },
+    "calculated_statement_descriptor": "ACADEMY.EICORN.COM",
+    "captured": true,
+    "created": 1608812162,
+    "currency": "eur",
+    "customer": "cus_IdummyM0lzFHz",
+    "description": "ORD001737: ISO 56002 Innovation Management - Eicorn Academy",
+    "destination": null,
+    "dispute": null,
+    "disputed": false,
+    "failure_code": null,
+    "failure_message": null,
+    "fraud_details": {},
+    "invoice": null,
+    "livemode": true,
+    "metadata": {
+      "order_id": "20679297",
+      "first_name": "dummy",
+      "last_name": "name",
+      "email": "another_dummy@example.com",
+      "ip_address": "79.9.102.47",
+      "company_or_organisation": "Project sas",
+      "country": "GR"
+    },
+    "on_behalf_of": null,
+    "order": null,
+    "outcome": {
+      "network_status": "approved_by_network",
+      "reason": null,
+      "risk_level": "normal",
+      "seller_message": "Payment complete.",
+      "type": "authorized"
+    },
+    "paid": true,
+    "payment_intent": "pi_1I1sjeBdummygk3hI",
+    "payment_method": "pm_1I1cMIdummyduSSxwro",
+    "payment_method_details": {
+      "card": {
+        "brand": "mastercard",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": null
+        },
+        "country": "GR",
+        "exp_month": 7,
+        "exp_year": 2021,
+        "fingerprint": "dummy",
+        "funding": "prepaid",
+        "installments": null,
+        "last4": "0000",
+        "network": "mastercard",
+        "three_d_secure": null,
+        "wallet": null
+      },
+      "type": "card"
+    },
+    "receipt_email": null,
+    "receipt_number": null,
+    "receipt_url": "https://pay.stripe.com/receipts/acct_1dummyfRT94/ch_1I1sjeBqdummy94dh06xTnx/rcpt_Id91eUPCSmxwQ6KC06HgpjAXU3clFtE",
+    "refunded": false,
+    "refunds": {
+      "object": "list",
+      "data": [],
+      "has_more": false,
+      "total_count": 0,
+      "url": "/v1/charges/ch_1I1sjeBqdummy94dh06xTnx/refunds"
+    },
+    "review": null,
+    "shipping": null,
+    "source": null,
+    "source_transfer": null,
+    "statement_descriptor": null,
+    "statement_descriptor_suffix": null,
+    "status": "succeeded",
+    "transfer_data": null,
+    "transfer_group": null
+  }
+]

--- a/spec/moss_generator/stripe_spec.rb
+++ b/spec/moss_generator/stripe_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe MossGenerator::Stripe do
       expect(call).to eq(result)
     end
 
+    context 'when country is greece (GR)' do
+      let(:charges) do
+        JSON.parse(File.read('spec/fixtures/stripe_charges_from_greece.json'))
+      end
+
+      it 'returns a csv format string with country code EL' do
+        result = "OSS_001;\r\n"\
+                 "SE556000016701;3;2020;\r\n"\
+                 "SE;EL;24,00;202,58;48,62;GOODS;\r\n"\
+
+        expect(call).to eq(result)
+      end
+    end
+
     context 'with special_vat_rate_for_2021_quarter_one' do
       subject { true }
 


### PR DESCRIPTION
Skatteverket uses EU own country code definition with more native codes, therefore greece code is not GR, but instead EL